### PR TITLE
Request to create 1.0.5 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Salesforce Unified SDK for iOS
 This is the git repository for the Salesforce Marketing Cloud Unified SDK for iOS.
+


### PR DESCRIPTION
When attempting to install MarketingCloudSDK-iOS, it's dependency on the MarketingCloud-SFMCSdk causes installation failure, as Cocoapods is unable to find the 1.0.5 branch on this repo. Recreating this branch or modifying the cocoapod spec may be necessary to get this working.